### PR TITLE
Added BoatName in the NMEA message

### DIFF
--- a/dashboard.js
+++ b/dashboard.js
@@ -2230,8 +2230,13 @@ var controller = function () {
                                 curr_sailor.mmsi = crc32(curr_sailor.displayName) & 0x3FFFFFFF;
                             }
 
+                            // Send position report data (Type1)
                             var aivdm = formatAIVDM_AIS_msg1(curr_sailor.mmsi, curr_sailor);
                             sendSentence(r.id, "$" + aivdm + "*" + nmeaChecksum(aivdm));
+                            // Send static and voyage related data (Type5)
+                            aivdm = formatAIVDM_AIS_msg5(curr_sailor.mmsi, curr_sailor);
+                            sendSentence(r.id, "$" + aivdm + "*" + nmeaChecksum(aivdm));
+
                         }
                     }
                 }
@@ -2330,7 +2335,45 @@ var controller = function () {
 
 
         // Convert bitArray to ASCII
+        var str = bitArray2ASCII(bitArray);
 
+        return str;
+    }
+
+    function formatUtilAIVDM_AIS_msg5(mmsi, uinfo)
+    {
+        var bitArray = [];
+
+        bitArray += longToBitArray(5, 6);                                       // Message type 5
+        bitArray += longToBitArray(0, 2);                                       // Message repeat indicator
+
+        bitArray += longToBitArray(mmsi, 30);                                   // Boat MMSI
+        bitArray += longToBitArray(0, 2);                                       // AIS Version
+        bitArray += longToBitArray(uinfo.mmsi, 30);                             // IMO Number
+        bitArray += longToBitArray(0, 42);                                      // Call Sign - 7 six-bit characters
+        bitArray += longToBitArray(0, 120);                                     // Vessel Name - 20 six-bit characters => uinfo.displayName
+        bitArray += longToBitArray(0, 8);                                       // Ship Type => not available
+        bitArray += longToBitArray(0, 9);                                       // Dimension to Bow
+        bitArray += longToBitArray(0, 9);                                       // Dimension to Stern
+        bitArray += longToBitArray(0, 6);                                       // Dimension to Port
+        bitArray += longToBitArray(0, 6);                                       // Dimension to Starboard
+        bitArray += longToBitArray(0, 4);                                       // Position Fix Type => Undefined
+        bitArray += longToBitArray(0, 4);                                       // ETA month => Undefined
+        bitArray += longToBitArray(0, 5);                                       // ETA day => Undefined
+        bitArray += longToBitArray(0, 5);                                       // ETA hour => Undefined
+        bitArray += longToBitArray(0, 6);                                       // ETA minute => Undefined
+        bitArray += longToBitArray(0, 8);                                       // Draught
+        bitArray += longToBitArray(0, 120);                                     // Destination - 20 six-bit characters
+        bitArray += longToBitArray(1, 1);                                       // DTE => 1 == Not ready (default)
+        bitArray += longToBitArray(0, 1);                                       // Spare
+
+        // Convert bitArray to ASCII
+        var str = bitArray2ASCII(bitArray);
+        return str;
+    }
+
+    function bitArray2ASCII(bitArray)
+    {
         // * Prepare conversion
         var map_bit_to_ascii = {};
 
@@ -2361,14 +2404,28 @@ var controller = function () {
         return str;
     }
 
+
     function formatAIVDM_AIS_msg1 (mmsi, uinfo) {
         // https://castoo.pagesperso-orange.fr/navigation/analys_nmea_ais.html
         var s = "AIVDM";
-        s += "," + "1";                                        // number of fragment
+        s += "," + "2";                                        // number of fragment
         s += "," + "1";                                        // fragment number
-        s += "," + "";                                         // message id
+        s += "," + "1";                                         // message id
         s += "," + "B";                                        // Radio Canal
         s += "," + formatUtilAIVDM_AIS_msg1(mmsi, uinfo);      // payload
+        s += ",0"                                              // padding
+
+        return s;
+    }
+
+    function formatAIVDM_AIS_msg5 (mmsi, uinfo) {
+        // https://castoo.pagesperso-orange.fr/navigation/analys_nmea_ais.html
+        var s = "AIVDM";
+        s += "," + "2";                                        // number of fragment
+        s += "," + "2";                                        // fragment number
+        s += "," + "1";                                         // message id
+        s += "," + "B";                                        // Radio Canal
+        s += "," + formatUtilAIVDM_AIS_msg5(mmsi, uinfo);      // payload
         s += ",0"                                              // padding
 
         return s;

--- a/dashboard.js
+++ b/dashboard.js
@@ -2413,6 +2413,8 @@ var controller = function () {
         }
 
         // * Convert
+        // Pad the bitArray to a round length of 6 bits
+        bitArray += longToBitArray(0, 6 - (bitArray.length % 6));
         var str = "";
         for (var i = 0; i < (bitArray.length / 6); i++)
         {
@@ -2444,7 +2446,7 @@ var controller = function () {
         s += "," + "";                                         // message id
         s += "," + "B";                                        // Radio Canal
         s += "," + formatUtilAIVDM_AIS_msg5(mmsi, uinfo);      // payload
-        s += ",0"                                              // padding
+        s += ",4"                                              // padding
 
         return s;
     }

--- a/dashboard.js
+++ b/dashboard.js
@@ -2312,6 +2312,19 @@ var controller = function () {
         return bitArray;
     };
 
+    function stringToBitArray(s, array_size) {
+        var bitArray = [];
+        var bytes = s.getBytes();
+
+        for (var i = 0; i < min(bytes.length, array_size); i++)
+        {
+            var b = bytes[i];
+            bitArray = [b & 64 | 63] + bitArray;
+        }
+
+        return bitArray;
+    };
+
     function formatUtilAIVDM_AIS_msg1(mmsi, uinfo)
     {
         var bitArray = [];
@@ -2351,7 +2364,7 @@ var controller = function () {
         bitArray += longToBitArray(0, 2);                                       // AIS Version
         bitArray += longToBitArray(uinfo.mmsi, 30);                             // IMO Number
         bitArray += longToBitArray(0, 42);                                      // Call Sign - 7 six-bit characters
-        bitArray += longToBitArray(0, 120);                                     // Vessel Name - 20 six-bit characters => uinfo.displayName
+        bitArray += stringToBitArray(uinfo.displayName, 120);                   // Vessel Name - 20 six-bit characters
         bitArray += longToBitArray(0, 8);                                       // Ship Type => not available
         bitArray += longToBitArray(0, 9);                                       // Dimension to Bow
         bitArray += longToBitArray(0, 9);                                       // Dimension to Stern

--- a/dashboard.js
+++ b/dashboard.js
@@ -2232,10 +2232,10 @@ var controller = function () {
 
                             // Send position report data (Type1)
                             var aivdm = formatAIVDM_AIS_msg1(curr_sailor.mmsi, curr_sailor);
-                            sendSentence(r.id, "$" + aivdm + "*" + nmeaChecksum(aivdm));
+                            sendSentence(r.id, "!" + aivdm + "*" + nmeaChecksum(aivdm));
                             // Send static and voyage related data (Type5)
                             aivdm = formatAIVDM_AIS_msg5(curr_sailor.mmsi, curr_sailor);
-                            sendSentence(r.id, "$" + aivdm + "*" + nmeaChecksum(aivdm));
+                            sendSentence(r.id, "!" + aivdm + "*" + nmeaChecksum(aivdm));
 
                         }
                     }
@@ -2312,16 +2312,21 @@ var controller = function () {
         return bitArray;
     };
 
-    function stringToBitArray(s, array_size) {
+    function stringToSixBitArray(s, sixBitsArraySize) {
         var bitArray = [];
-        //var bytes = s.getBytes();
-
-        for (var i = 0; i < min(s.length, array_size); i++)
+        s = s.toUpperCase();
+        for (var i = 0; i < Math.min(s.length, sixBitsArraySize); i++)
         {
-            var b = s[i].charCodeAt();
-            bitArray = [b & 64 | 63] + bitArray;
+            var b = s.charCodeAt(i);
+            bitArray += longToBitArray((b | 64) & 63, 6);
         }
-
+        // Pad with spaces (32)
+        if ( s.length < sixBitsArraySize) {
+            //bitArray += longToBitArray(0, 6);
+            for (var i = 0; i < sixBitsArraySize - s.length; i++) {
+                bitArray += longToBitArray(32, 6);
+            }
+        }
         return bitArray;
     };
 
@@ -2364,8 +2369,8 @@ var controller = function () {
         bitArray += longToBitArray(0, 2);                                       // AIS Version
         bitArray += longToBitArray(uinfo.mmsi, 30);                             // IMO Number
         bitArray += longToBitArray(0, 42);                                      // Call Sign - 7 six-bit characters
-        bitArray += stringToBitArray(uinfo.displayName, 120);                   // Vessel Name - 20 six-bit characters
-        bitArray += longToBitArray(0, 8);                                       // Ship Type => not available
+        bitArray += stringToSixBitArray(uinfo.displayName, 120/6);              // Vessel Name - 20 six-bit characters
+        bitArray += longToBitArray(36, 8);                                      // Ship Type => Sailing
         bitArray += longToBitArray(0, 9);                                       // Dimension to Bow
         bitArray += longToBitArray(0, 9);                                       // Dimension to Stern
         bitArray += longToBitArray(0, 6);                                       // Dimension to Port
@@ -2421,9 +2426,9 @@ var controller = function () {
     function formatAIVDM_AIS_msg1 (mmsi, uinfo) {
         // https://castoo.pagesperso-orange.fr/navigation/analys_nmea_ais.html
         var s = "AIVDM";
-        s += "," + "2";                                        // number of fragment
+        s += "," + "1";                                        // number of fragment
         s += "," + "1";                                        // fragment number
-        s += "," + "1";                                         // message id
+        s += "," + "";                                         // message id
         s += "," + "B";                                        // Radio Canal
         s += "," + formatUtilAIVDM_AIS_msg1(mmsi, uinfo);      // payload
         s += ",0"                                              // padding
@@ -2434,9 +2439,9 @@ var controller = function () {
     function formatAIVDM_AIS_msg5 (mmsi, uinfo) {
         // https://castoo.pagesperso-orange.fr/navigation/analys_nmea_ais.html
         var s = "AIVDM";
-        s += "," + "2";                                        // number of fragment
-        s += "," + "2";                                        // fragment number
-        s += "," + "1";                                         // message id
+        s += "," + "1";                                        // number of fragment
+        s += "," + "1";                                        // fragment number
+        s += "," + "";                                         // message id
         s += "," + "B";                                        // Radio Canal
         s += "," + formatUtilAIVDM_AIS_msg5(mmsi, uinfo);      // payload
         s += ",0"                                              // padding

--- a/dashboard.js
+++ b/dashboard.js
@@ -2314,11 +2314,11 @@ var controller = function () {
 
     function stringToBitArray(s, array_size) {
         var bitArray = [];
-        var bytes = s.getBytes();
+        //var bytes = s.getBytes();
 
-        for (var i = 0; i < min(bytes.length, array_size); i++)
+        for (var i = 0; i < min(s.length, array_size); i++)
         {
-            var b = bytes[i];
+            var b = s[i].charCodeAt();
             bitArray = [b & 64 | 63] + bitArray;
         }
 


### PR DESCRIPTION
Sending Message#5 that contains the boatname
Boat names are truncated to 20 chars, the max authorized
This is working in Adrena
Known Issues

numbers and uncovered chars are not well decoded. At least we should have numbers, but I don't know why this is failing. Numbers are converted to lowercase characters
Field "Ship Type" have been set to 36 (Sailing), but this doesn't shows up in Adrena